### PR TITLE
Fixed typo in comments documentation

### DIFF
--- a/sections/comments.md
+++ b/sections/comments.md
@@ -1,7 +1,7 @@
 Comments
 ========
 
-To determine if a resource can be commented on, check for the presences of `comment_count` and `comments_url` attributes in its JSON response.
+To determine if a resource can be commented on, check for the presences of `comments_count` and `comments_url` attributes in its JSON response.
 
 Endpoints:
 


### PR DESCRIPTION
Changed attribute name in the documentation, the field for knowing the number of comments is `comments_count` rather than `comment_count`.