### PR TITLE
Document Card Column Steps API

### DIFF
--- a/sections/card_table_cards.md
+++ b/sections/card_table_cards.md
@@ -163,7 +163,84 @@ Get a card
 
   ],
   "completion_url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069482295/completion.json",
-  "comment_count": 0
+  "comment_count": 0,
+  "steps": [
+    {
+      "id": 1069483883,
+      "status": "active",
+      "visible_to_clients": false,
+      "created_at": "2023-04-11T19:03:00.000Z",
+      "updated_at": "2023-04-11T19:03:00.000Z",
+      "title": "Find inspiration",
+      "inherits_status": true,
+      "type": "Kanban::Step",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069483883.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069483882#__recording_1069483883",
+      "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDgzODgzP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--a6b622a4a8155f7db3ade5304666300199d8e4cf.json",
+      "position": 1,
+      "parent": {
+        "id": 1069483882,
+        "title": "New and fancy UI",
+        "type": "Kanban::Card",
+        "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069483882.json",
+        "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069483882"
+      },
+      "bucket": {
+        "id": 2085958499,
+        "name": "The Leto Laptop",
+        "type": "Project"
+      },
+      "creator": {
+        "id": 1049716108,
+        "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE2MTA4P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--33a0d8ee2b0bbcc0136cc0405d56b65b76e98b56",
+        "name": "Victor Cooper",
+        "email_address": "victor@honchodesign.com",
+        "personable_type": "User",
+        "title": "Chief Strategist",
+        "bio": "Don’t let your dreams be dreams",
+        "location": "Chicago, IL",
+        "created_at": "2023-04-25T09:09:57.914Z",
+        "updated_at": "2023-04-25T09:10:02.829Z",
+        "admin": true,
+        "owner": true,
+        "client": false,
+        "employee": true,
+        "time_zone": "America/Chicago",
+        "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBIxlkT4=--f8ea82b59ac303fe025fd537009cbeda9c381290/avatar?v=1",
+        "company": {
+          "id": 1033447830,
+          "name": "Honcho Design"
+        },
+        "can_manage_projects": true,
+        "can_manage_people": true
+      },
+      "completed": false,
+      "due_on": "2023-04-29",
+      "assignees": [
+        {
+          "id": 1049716126,
+          "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE2MTI2P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--54e94dd33334db927ffaa203f3eebf85b24f352a",
+          "name": "Tashia Hughes",
+          "email_address": "tashia@honchodesign.com",
+          "personable_type": "User",
+          "title": "District Integration Architect",
+          "bio": null,
+          "location": null,
+          "created_at": "2023-04-25T09:10:07.254Z",
+          "updated_at": "2023-04-25T09:10:07.254Z",
+          "admin": false,
+          "owner": false,
+          "client": false,
+          "employee": false,
+          "time_zone": "America/Chicago",
+          "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBJ5lkT4=--2d1100b45114d017a5327b8dce82ebc351fcbbd4/avatar?v=1",
+          "can_manage_projects": true,
+          "can_manage_people": true
+        }
+      ],
+      "completion_url": "/195539477/buckets/2085958499/card_tables/steps/1069483883/completions.json"
+    }
+  ]
 }
 ```
 <!-- END GET /buckets/1/card_tables/cards/2.json -->

--- a/sections/card_table_steps.md
+++ b/sections/card_table_steps.md
@@ -99,7 +99,7 @@ This endpoint will return `200 OK` with the current JSON representation of the s
 ``` shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
   -d '{"kanban_step": {"completion": "on"}}' -X PUT \
-  https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/steps/2/completion.json
+  https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/steps/2/completions.json
 ```
 
 Reposition a step
@@ -125,7 +125,7 @@ This endpoint will return `204 No Content` if successful.
 
 ``` shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
-  -d '{"source_id": 1069484048, "position": 4}' -X POST \
+  -d '{"source_id": 3, "position": 4}' -X POST \
   https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/cards/2/positions.json
 ```
 

--- a/sections/card_table_steps.md
+++ b/sections/card_table_steps.md
@@ -1,0 +1,133 @@
+Card table steps
+================
+
+Endpoints:
+
+- [Get steps in a card](#get-steps-in-a-card)
+- [Create a step](#create-a-step)
+- [Update a step](#update-a-step)
+- [Change step completion status](#change-step-completion-status)
+- [Reposition a step](#reposition-a-step)
+
+Get steps in a card
+--------------------
+
+Steps are returned unpaginated as part of the [Get a card][card] endpoint payload.
+
+Create a step
+-------------------------
+
+* `POST /buckets/1/card_tables/cards/2/steps.json` creates a step within the card with ID `2` in the project with id `1`.
+
+**Required parameters**: `title` of the step.
+
+_Optional parameters_:
+
+* `due_on` - due date (ISO 8601) of the step.
+* `assignees` - a comma separated list of people ids that will be assigned to this step. Please see the [Get people][people] endpoints to retrieve them.
+
+This endpoint will return `201 Created` with the current JSON representation of the step if the creation was a success. See the step property of the [Get a card][card] endpoint for more info on the payload.
+
+###### Example JSON Request
+
+``` json
+{
+  "title": "Inspiration",
+  "due_on": "2021-01-01",
+  "assignees": "30068628,270913789"
+}
+```
+
+###### Copy as cURL
+
+``` shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
+  -d '{"kanban_step": {"title": "Inspiration", "due_on": "2021-01-01", "assignees": "30068628,270913789"}}' \
+  https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/cards/2/steps.json
+```
+
+Update a step
+-----------------------
+
+* `PUT /buckets/1/card_tables/steps/2.json` allows changing of the step with an ID of `2` in the project with ID `1`.
+
+_Optional parameters_:
+
+* `title` - of the card.
+* `due_on` - due date (ISO 8601) of the step.
+* `assignees` - a comma separated list of people ids that will be assigned to this step. Please see the [Get people][people] endpoints to retrieve them.
+
+This endpoint will return `200 OK` with the current JSON representation of the step if the update was a success. See the step property of the [Get a card][card] endpoint for more info on the payload.
+
+###### Example JSON Request
+
+``` json
+{
+  "title": "Updated inspiration"
+}
+```
+
+###### Copy as cURL
+
+``` shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
+  -d '{"kanban_step": {"title": "Updated inspiration"}}' -X PUT \
+  https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/steps/2.json
+```
+
+Change step completion status
+-----------------------------
+
+* `PUT /buckets/1/card_tables/steps/2/completion.json` will mark the step with an ID of `2` in the project with ID `1` as completed or uncompleted depending on the completion parameter.
+
+**Required parameters**:
+
+* `completion` – Set to "on" to mark the step as completed and to "off" to mark the step as uncompleted.
+
+This endpoint will return `200 OK` with the current JSON representation of the step if the update was a success. See the step property of the [Get a card][card] endpoint for more info on the payload.
+
+###### Example JSON Request
+
+``` json
+{
+  "completion": "on"
+}
+```
+
+###### Copy as cURL
+
+``` shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
+  -d '{"kanban_step": {"completion": "on"}}' -X PUT \
+  https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/steps/2/completion.json
+```
+
+Reposition a step
+-----------------------------
+
+* `POST /buckets/1/card_tables/cards/2/positions.json` allows changing the position of the step with an ID of `source_id` in the card with id `2`.
+
+**Required parameters**:
+
+* `source_id` – the step id. Step ids can be found via the [Get a card][card] endpoint.
+* `position` – Zero indexed.
+
+This endpoint will return `204 No Content` if successful.
+
+###### Example JSON Request
+
+``` json
+{
+  "source_id": 3,
+  "position": 4
+}
+```
+
+``` shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
+  -d '{"source_id": 1069484048, "position": 4}' -X POST \
+  https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/cards/2/positions.json
+```
+
+[card]: https://github.com/basecamp/bc3-api/blob/master/sections/card_table_cards.md#get-a-card
+[people]: https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-all-people


### PR DESCRIPTION
Documents the card table steps public API. I propose that steps are considered a card detail and thus have no dedicated show / index endpoints. This mirrors how we treat them in the UI (steps don't have permas) and doesn't require us to add bespoke controller actions for the API.

I don't have a strong preference here and if we think that dedicated endpoints to e.g get a single step is needed I don't mind adding it.

There is a branch that makes a few smaller adjustments to adhere to the proposed design [here](https://github.com/basecamp/bc3/compare/ramhoj/steps-api?expand=1). Once we agree on the API design I will submit it as  PR.