### PR TITLE
Requests are not working without kanban_step

### DIFF
--- a/sections/card_table_steps.md
+++ b/sections/card_table_steps.md
@@ -32,9 +32,11 @@ This endpoint will return `201 Created` with the current JSON representation of 
 
 ``` json
 {
-  "title": "Inspiration",
-  "due_on": "2021-01-01",
-  "assignees": "30068628,270913789"
+  "kanban_step": {
+    "title": "Inspiration",
+    "due_on": "2021-01-01",
+    "assignees": "30068628,270913789"
+  }
 }
 ```
 


### PR DESCRIPTION
It is not possible to create a step how it is currently documented. 

It says the body of the request should be something like:
{
    "title": "Inspiration",
    "due_on": "2021-01-01",
    "assignees": "30068628,270913789"
 }
 
 but the only way I found it to work was like this:
 
 {
  "kanban_step": {
    "title": "Inspiration",
    "due_on": "2021-01-01",
    "assignees": "30068628,270913789"
  }
}
