### PR TITLE
Remove kanban_card and kanan_step namespace from curl examples

### DIFF
--- a/sections/card_table_cards.md
+++ b/sections/card_table_cards.md
@@ -278,7 +278,7 @@ This endpoint will return `201 Created` with the current JSON representation of 
 
 ``` shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
-  -d '{"kanban_card": {"title":"Investigation", "content": "Investigate on an issue in our todo list.", "due_on": "2021-01-01"}}' \
+  -d '{"title":"Investigation", "content": "Investigate on an issue in our todo list.", "due_on": "2021-01-01"}' \
   https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/lists/2/cards.json
 ```
 
@@ -308,7 +308,7 @@ This endpoint will return `200 OK` with the current JSON representation of the c
 
 ``` shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
-  -d '{"kanban_card": {"title":"Updated investigation"}}' -X PUT \
+  -d '{"title":"Updated investigation"}' -X PUT \
   https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/cards/2.json
 ```
 

--- a/sections/card_table_steps.md
+++ b/sections/card_table_steps.md
@@ -32,11 +32,9 @@ This endpoint will return `201 Created` with the current JSON representation of 
 
 ``` json
 {
-  "kanban_step": {
-    "title": "Inspiration",
-    "due_on": "2021-01-01",
-    "assignees": "30068628,270913789"
-  }
+  "title": "Inspiration",
+  "due_on": "2021-01-01",
+  "assignees": "30068628,270913789"
 }
 ```
 
@@ -44,7 +42,7 @@ This endpoint will return `201 Created` with the current JSON representation of 
 
 ``` shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
-  -d '{"kanban_step": {"title": "Inspiration", "due_on": "2021-01-01", "assignees": "30068628,270913789"}}' \
+  -d '{"title": "Inspiration", "due_on": "2021-01-01", "assignees": "30068628,270913789"}' \
   https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/cards/2/steps.json
 ```
 
@@ -73,7 +71,7 @@ This endpoint will return `200 OK` with the current JSON representation of the s
 
 ``` shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
-  -d '{"kanban_step": {"title": "Updated inspiration"}}' -X PUT \
+  -d '{"title": "Updated inspiration"}' -X PUT \
   https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/steps/2.json
 ```
 
@@ -100,7 +98,7 @@ This endpoint will return `200 OK` with the current JSON representation of the s
 
 ``` shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
-  -d '{"kanban_step": {"completion": "on"}}' -X PUT \
+  -d '{"completion": "on"}' -X PUT \
   https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/card_tables/steps/2/completions.json
 ```
 


### PR DESCRIPTION
While we do support both un-nested and nested versions using the same nesting in the json and curl examples makes it easier to reason about.

I will mark this PR as ready once the necessary change to support un-nested step parameters is merged.