### PR TITLE
Document the Lineup::Marker API

### DIFF
--- a/sections/lineup_markers.md
+++ b/sections/lineup_markers.md
@@ -1,0 +1,80 @@
+Lineup Markers
+================
+
+Endpoints:
+
+- [Create a marker](#create-a-marker)
+- [Update a marker](#update-a-marker)
+- [Destroy a marker](#destroy-a-step)
+
+Create a marker
+-------------------------
+
+* `POST /lineup/markers.json` creates an account wide marker that shows up in the Lineup.
+
+**Required parameters**:
+
+* `name` of the marker.
+* `date` of the marker iso8601 formatted without a time part.
+
+This endpoint will return `201 Created` with an empty response body.
+
+###### Example JSON Request
+
+``` json
+{
+  "name": "Anniversary",
+  "date": "2021-01-01"
+}
+```
+
+###### Copy as cURL
+
+``` shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
+  -d '{"name": "Anniversary", "date": "2021-01-01"}' \
+  https://3.basecampapi.com/$ACCOUNT_ID/lineup/markers.json
+```
+
+Update a marker
+-----------------------
+
+* `PUT /lineup/markers/1.json` change name and/or date of the marker with an ID of `1`.
+
+_Optional parameters_:
+
+* `name` of the marker.
+* `date` of the marker iso8601 formatted without a time part.
+
+This endpoint will return `200 OK` with an empty response body.
+
+###### Example JSON Request
+
+``` json
+{
+  "name": "Updated anniversary"
+}
+```
+
+###### Copy as cURL
+
+``` shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
+  -d '{"name": "Updated anniversary"}' -X PUT \
+  https://3.basecampapi.com/$ACCOUNT_ID/lineup/markers/1.json
+```
+
+Destroy a marker
+-----------------------
+
+* `DELETE /lineup/markers/1.json` permanently destroys the marker with an ID of `1` immediately.
+
+This endpoint will return `204 No Content`.
+
+###### Copy as cURL
+
+``` shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
+  -X DELETE \
+  https://3.basecampapi.com/$ACCOUNT_ID/lineup/markers/1.json
+```


### PR DESCRIPTION
The new Markers feature makes it possible to highlight important, company-wide dates and milestones in the Lineup, like the end of a quarter or the start of summer holidays. The marker appears as a vertical line with its name at the top, similar to Today.

You can create, update and destroy markers via the API but there is no endpoint to list them.

There can only be one marker per date and account. The API will return 422 with a json body containing validation errors if attempting to create a marker on a date that already has a marker.