### PR TITLE
Update messages.md to include missing parameter

### DIFF
--- a/sections/messages.md
+++ b/sections/messages.md
@@ -165,6 +165,7 @@ _Optional parameters_:
 * `content` as the body of the message. See our [Rich text guide][4] for what HTML tags are allowed.
 * `category_id` to set a type for the message. To get a list of all the message types for a project, see the [Get message types][5] endpoint. 
 * `subscriptions` an array of people IDs to be notified of the new message when it's posted and subscribed to it. If not present, all people on the project will be notified and subscribed.
+* `visible_to_clients` boolean setting the visiblility of the created message. Default `false`
 
 This endpoint will return `201 Created` with the current JSON representation of the message if the creation was a success. See the [Get a message](#get-a-message) endpoint for more info on the payload.
 


### PR DESCRIPTION
Add undocumented optional `visible_to_clients` parameter to message creation endpoint documentation