### PR TITLE
Document notification settings and snooze API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ API endpoints
 - [Message Boards](https://github.com/basecamp/bc3-api/blob/master/sections/message_boards.md#message-boards)
 - [Message Types](https://github.com/basecamp/bc3-api/blob/master/sections/message_types.md#message-types)
 - [Messages](https://github.com/basecamp/bc3-api/blob/master/sections/messages.md#messages)
+- [Notification settings](https://github.com/basecamp/bc3-api/blob/master/sections/notification_settings.md#notification-settings)
 - [People](https://github.com/basecamp/bc3-api/blob/master/sections/people.md#people)
 - [Projects](https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#projects)
 - [Question answers](https://github.com/basecamp/bc3-api/blob/master/sections/question_answers.md#question-answers)

--- a/sections/notification_settings.md
+++ b/sections/notification_settings.md
@@ -1,0 +1,141 @@
+Notification settings
+=====================
+
+Endpoints for reading and updating the current user's notification preferences, including delivery platform, granularity, schedule, reminders, and snoozing.
+
+Endpoints:
+
+- [Get notification settings](#get-notification-settings)
+- [Update notification settings](#update-notification-settings)
+- [Snooze notifications](#snooze-notifications)
+
+
+Get notification settings
+-------------------------
+
+* `GET /my/notifications/settings.json` will return the current user's notification settings.
+
+###### Example JSON Response
+<!-- START GET /my/notifications/settings.json -->
+```json
+{
+  "platform": "web_and_email",
+  "granularity": "everything",
+  "show_badge_counts": true,
+  "schedule_enabled": false,
+  "schedule": null,
+  "bundle_enabled": true,
+  "schedule_entries_reminders": true,
+  "due_assignments_reminders": true,
+  "state": "on"
+}
+```
+<!-- END GET /my/notifications/settings.json -->
+
+When `schedule_enabled` is `true`, the `schedule` object is included:
+
+```json
+{
+  "schedule_enabled": true,
+  "schedule": {
+    "start_hour": 9,
+    "end_hour": 17,
+    "work_days": [1, 2, 3, 4, 5]
+  }
+}
+```
+
+###### Copy as cURL
+
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" https://3.basecampapi.com/$ACCOUNT_ID/my/notifications/settings.json
+```
+
+
+Update notification settings
+----------------------------
+
+* `PUT /my/notifications/settings.json` will update the current user's notification settings. Only the provided parameters are changed; omitted parameters remain unchanged. Returns `204 No Content` on success.
+
+_Optional parameters_:
+
+* `platform` - delivery platform. Valid options: `web`, `email`, `web_and_email`.
+* `granularity` - notification granularity. Valid options: `everything`, `pings_and_mentions`.
+* `show_badge_counts` - whether to show badge counts. `true` or `false`.
+* `schedule_enabled` - whether the notification schedule is active. `true` or `false`. When `true`, also provide `schedule`.
+* `schedule` - an object with `start_hour` (integer 0–23), `end_hour` (integer 0–23), and `work_days` (array of integers, 0=Sunday through 6=Saturday).
+* `bundle_enabled` - whether notification bundling is enabled. `true` or `false`. Requires `schedule_enabled` to be `true`.
+* `reminders` - an array of reminder types to enable. Valid values: `schedule_entries`, `due_assignments`. Pass an empty array to disable all reminders.
+
+Providing an invalid `platform` or `granularity` returns `422 Unprocessable Entity` with an error listing the valid options:
+
+```json
+{
+  "errors": [
+    "Invalid platform 'carrier_pigeon'. Valid options: web, email, web_and_email"
+  ]
+}
+```
+
+###### Example JSON Request
+<!-- START PUT PAYLOAD /my/notifications/settings.json -->
+```json
+{
+  "platform": "email",
+  "granularity": "pings_and_mentions",
+  "schedule_enabled": true,
+  "schedule": {
+    "start_hour": 9,
+    "end_hour": 17,
+    "work_days": [1, 2, 3, 4, 5]
+  },
+  "bundle_enabled": true,
+  "reminders": ["schedule_entries", "due_assignments"]
+}
+```
+<!-- END PUT PAYLOAD /my/notifications/settings.json -->
+
+###### Copy as cURL
+
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
+  -d '{"platform":"email","granularity":"pings_and_mentions"}' -X PUT \
+  https://3.basecampapi.com/$ACCOUNT_ID/my/notifications/settings.json
+```
+
+
+Snooze notifications
+--------------------
+
+* `PUT /my/notifications/snooze.json` will snooze the current user's notifications for the given duration. Returns `200 OK` with the snooze state.
+
+**Required parameters**:
+
+* `duration` - the number of seconds to snooze notifications.
+
+###### Example JSON Response
+<!-- START PUT /my/notifications/snooze.json -->
+```json
+{
+  "state": "snoozed",
+  "off_until": "2024-12-05T15:00:00Z"
+}
+```
+<!-- END PUT /my/notifications/snooze.json -->
+
+###### Example JSON Request
+<!-- START PUT PAYLOAD /my/notifications/snooze.json -->
+```json
+{
+  "duration": 10800
+}
+```
+<!-- END PUT PAYLOAD /my/notifications/snooze.json -->
+
+###### Copy as cURL
+
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
+  -d '{"duration":10800}' -X PUT \
+  https://3.basecampapi.com/$ACCOUNT_ID/my/notifications/snooze.json
+```

--- a/sections/notification_settings.md
+++ b/sections/notification_settings.md
@@ -25,8 +25,7 @@ Get notification settings
   "schedule_enabled": false,
   "schedule": null,
   "bundle_enabled": true,
-  "schedule_entries_reminders": true,
-  "due_assignments_reminders": true,
+  "reminders": ["schedule_entries", "due_assignments"],
   "state": "on"
 }
 ```
@@ -71,9 +70,7 @@ Providing an invalid `platform` or `granularity` returns `422 Unprocessable Enti
 
 ```json
 {
-  "errors": [
-    "Invalid platform 'carrier_pigeon'. Valid options: web, email, web_and_email"
-  ]
+  "error": "Invalid platform 'carrier_pigeon'. Valid options: web, email, web_and_email"
 }
 ```
 

--- a/sections/notification_settings.md
+++ b/sections/notification_settings.md
@@ -64,7 +64,7 @@ _Optional parameters_:
 * `show_badge_counts` - whether to show badge counts. `true` or `false`.
 * `schedule_enabled` - whether the notification schedule is active. `true` or `false`. When `true`, also provide `schedule`.
 * `schedule` - an object with `start_hour` (integer 0–23), `end_hour` (integer 0–23), and `work_days` (array of integers, 0=Sunday through 6=Saturday).
-* `bundle_enabled` - whether notification bundling is enabled. `true` or `false`. Requires `schedule_enabled` to be `true`.
+* `bundle_enabled` - whether notification bundling is enabled. `true` or `false`.
 * `reminders` - an array of reminder types to enable. Valid values: `schedule_entries`, `due_assignments`. Pass an empty array to disable all reminders.
 
 Providing an invalid `platform` or `granularity` returns `422 Unprocessable Entity` with an error listing the valid options:

--- a/sections/notification_settings.md
+++ b/sections/notification_settings.md
@@ -25,7 +25,8 @@ Get notification settings
   "schedule_enabled": false,
   "schedule": null,
   "bundle_enabled": true,
-  "reminders": ["schedule_entries", "due_assignments"],
+  "schedule_entries_reminders": true,
+  "due_assignments_reminders": true,
   "state": "on"
 }
 ```
@@ -64,13 +65,13 @@ _Optional parameters_:
 * `schedule_enabled` - whether the notification schedule is active. `true` or `false`. When `true`, also provide `schedule`.
 * `schedule` - an object with `start_hour` (integer 0–23), `end_hour` (integer 0–23), and `work_days` (array of integers, 0=Sunday through 6=Saturday).
 * `bundle_enabled` - whether notification bundling is enabled. `true` or `false`.
-* `reminders` - an array of reminder types to enable. Valid values: `schedule_entries`, `due_assignments`. Pass an empty array to disable all reminders.
+* `reminders` - an array of reminder types to enable. Valid values: `schedule_entries`, `due_assignments`. Pass an empty array to disable all reminders. These correspond to the `schedule_entries_reminders` and `due_assignments_reminders` boolean fields in the GET response.
 
 Providing an invalid `platform` or `granularity` returns `422 Unprocessable Entity` with an error listing the valid options:
 
 ```json
 {
-  "error": "Invalid platform 'carrier_pigeon'. Valid options: web, email, web_and_email"
+  "errors": ["Invalid platform 'carrier_pigeon'. Valid options: web, email, web_and_email"]
 }
 ```
 

--- a/sections/notification_settings.md
+++ b/sections/notification_settings.md
@@ -61,10 +61,10 @@ _Optional parameters_:
 
 * `platform` - delivery platform. Valid options: `web`, `email`, `web_and_email`.
 * `granularity` - notification granularity. Valid options: `everything`, `pings_and_mentions`.
-* `show_badge_counts` - whether to show badge counts. `true` or `false`.
-* `schedule_enabled` - whether the notification schedule is active. `true` or `false`. When `true`, also provide `schedule`.
-* `schedule` - an object with `start_hour` (integer 0–23), `end_hour` (integer 0–23), and `work_days` (array of integers, 0=Sunday through 6=Saturday).
-* `bundle_enabled` - whether notification bundling is enabled. `true` or `false`.
+* `show_badge_counts` - whether to show badge counts. JSON `true` or `false` (not strings).
+* `schedule_enabled` - whether the notification schedule is active. JSON `true` or `false` (not strings). When `true`, also provide `schedule`.
+* `schedule` - an object with `start_hour` (integer 0–23), `end_hour` (integer 0–23, must be greater than `start_hour`), and `work_days` (non-empty array of integers, 0=Sunday through 6=Saturday).
+* `bundle_enabled` - whether notification bundling is enabled. JSON `true` or `false` (not strings).
 * `reminders` - an array of reminder types to enable. Valid values: `schedule_entries`, `due_assignments`. Pass an empty array to disable all reminders. These correspond to the `schedule_entries_reminders` and `due_assignments_reminders` boolean fields in the GET response.
 
 Providing an invalid `platform` or `granularity` returns `422 Unprocessable Entity` with an error listing the valid options:
@@ -109,7 +109,7 @@ Snooze notifications
 
 **Required parameters**:
 
-* `duration` - the number of seconds to snooze notifications.
+* `duration` - a positive integer representing the number of seconds to snooze notifications.
 
 ###### Example JSON Response
 <!-- START PUT /my/notifications/snooze.json -->


### PR DESCRIPTION
## Summary

- Add `sections/notification_settings.md` documenting three new API endpoints from basecamp/bc3#9931:
  - `GET /my/notifications/settings.json` — read notification preferences
  - `PUT /my/notifications/settings.json` — partial update with enum validation
  - `PUT /my/notifications/snooze.json` — snooze notifications for a duration
- Add "Notification settings" to the README endpoint index