### PR TITLE
Add API documentation for account ownership endpoints

### DIFF
--- a/sections/account.md
+++ b/sections/account.md
@@ -5,6 +5,8 @@ Endpoints:
 
 - [Get account](#get-account)
 - [Update account name](#update-account-name)
+- [Grant account ownership](#grant-account-ownership)
+- [Revoke account ownership](#revoke-account-ownership)
 - [Update account logo](#update-account-logo)
 - [Remove account logo](#remove-account-logo)
 
@@ -128,6 +130,68 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
   https://3.basecampapi.com/$ACCOUNT_ID/account/name.json
 ```
 
+Grant account ownership
+-----------------------
+
+* `POST /account/people/2/ownership.json` will make the person with the given ID an account owner. Only account owners can use this endpoint — returns `403 Forbidden` for non-owners. Clients cannot be made owners.
+
+**Required parameters**:
+
+* `person_id` - the ID of the person to promote. The person must belong to the current account.
+
+Returns `200 OK` with the updated [person][person] JSON representation. On success, the response will have `"owner": true`.
+
+###### Example JSON Response
+<!-- START POST /account/people/2/ownership.json -->
+```json
+{
+  "id": 1049715915,
+  "name": "Amy Rivera",
+  "email_address": "amy@honchodesign.com",
+  "owner": true
+}
+```
+<!-- END POST /account/people/2/ownership.json -->
+
+###### Copy as cURL
+
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -X POST \
+  https://3.basecampapi.com/$ACCOUNT_ID/account/people/2/ownership.json
+```
+
+Revoke account ownership
+------------------------
+
+* `DELETE /account/people/2/ownership.json` will remove account ownership from the person with the given ID. Only account owners can use this endpoint — returns `403 Forbidden` for non-owners. You cannot revoke your own ownership.
+
+**Required parameters**:
+
+* `person_id` - the ID of the person whose ownership should be revoked. The person must belong to the current account.
+
+Returns `200 OK` with the updated [person][person] JSON representation. On success, the response will have `"owner": false`.
+
+###### Example JSON Response
+<!-- START DELETE /account/people/2/ownership.json -->
+```json
+{
+  "id": 1049715915,
+  "name": "Amy Rivera",
+  "email_address": "amy@honchodesign.com",
+  "owner": false
+}
+```
+<!-- END DELETE /account/people/2/ownership.json -->
+
+###### Copy as cURL
+
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -X DELETE \
+  https://3.basecampapi.com/$ACCOUNT_ID/account/people/2/ownership.json
+```
+
 Update account logo
 -------------------
 
@@ -164,3 +228,5 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
   -X DELETE \
   https://3.basecampapi.com/$ACCOUNT_ID/account/logo.json
 ```
+
+[person]: https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-person


### PR DESCRIPTION
## Summary
Document the JSON account ownership management endpoints added in https://github.com/basecamp/bc3/pull/10043

## Changes
- Add docs for `POST /account/people/:person_id/ownership.json`
- Add docs for `DELETE /account/people/:person_id/ownership.json`
- Note the account-owner-only permission requirements
- Document the returned Person JSON and `owner` flag behavior
- Add cURL examples for both endpoints