### PR TITLE
Basecamp 5 API: Campfire line editing, schedule recurrence, and to-do set to-dos

### DIFF
--- a/sections/campfires.md
+++ b/sections/campfires.md
@@ -10,6 +10,7 @@ Endpoints:
 - [Create a Campfire line](#create-a-campfire-line)
 - [Get Campfire uploads](#get-campfire-uploads)
 - [Upload a file to a Campfire](#upload-a-file-to-a-campfire)
+- [Update a Campfire line](#update-a-campfire-line)
 - [Delete a Campfire line](#delete-a-campfire-line)
 
 Get Campfires
@@ -627,17 +628,47 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
   https://3.basecampapi.com/$ACCOUNT_ID/chats/2/uploads.json?name=logo.png
 ```
 
+Update a Campfire line
+----------------------
+
+* `PUT /chats/2/lines/3.json` updates the Campfire line with ID `3` in the Campfire with ID `2`.
+
+**Required parameters**: `content` as the new body for the Campfire line.
+
+Only text and rich text lines can be edited, and only by their creator. The new content is treated as rich text: the line becomes a rich text line even if it was originally plain text, and `content` may include the HTML tags covered in our [Rich text guide][rich].
+
+Returns `204 No Content` if successful, or `403 Forbidden` if the current user isn't allowed to edit the line.
+
+###### Example JSON Request
+
+```json
+{
+  "content": "Good morning, <strong>everyone</strong>!"
+}
+```
+
+###### Copy as cURL
+
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
+  -d '{"content":"Good morning, <strong>everyone</strong>!"}' -X PUT \
+  https://3.basecampapi.com/$ACCOUNT_ID/chats/2/lines/3.json
+```
+
 Delete a Campfire line
 ----------------------
 
 * `DELETE /chats/2/lines/3.json` will delete the Campfire line with ID `3` in the Campfire with ID `2`.
 
-Returns `204 No Content` if successful.
+Lines can be deleted by their creator or by an admin.
+
+Returns `204 No Content` if successful, or `403 Forbidden` if the current user isn't allowed to delete the line.
 
 ###### Copy as cURL
 
 ```shell
-curl -s -H "Authorization: Bearer $ACCESS_TOKEN" https://3.basecampapi.com/$ACCOUNT_ID/chats/2/lines/3.json
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -X DELETE \
+  https://3.basecampapi.com/$ACCOUNT_ID/chats/2/lines/3.json
 ```
 
 Legacy project-scoped routes
@@ -651,6 +682,8 @@ The following project-scoped routes are still supported and will remain availabl
 * `POST /buckets/1/chats/2/lines.json` → [Create a Campfire line](#create-a-campfire-line)
 * `GET /buckets/1/chats/2/uploads.json` → [Get Campfire uploads](#get-campfire-uploads)
 * `POST /buckets/1/chats/2/uploads.json` → [Upload a file to a Campfire](#upload-a-file-to-a-campfire)
+* `PUT /buckets/1/chats/2/lines/3.json` → [Update a Campfire line](#update-a-campfire-line)
 * `DELETE /buckets/1/chats/2/lines/3.json` → [Delete a Campfire line](#delete-a-campfire-line)
 
 [pagination]: ../README.md#pagination
+[rich]: rich_text.md

--- a/sections/schedule_entries.md
+++ b/sections/schedule_entries.md
@@ -275,6 +275,15 @@ _Optional parameters_:
 * `participant_ids` - an array of people IDs that will participate in this entry. Please see the [Get people][people] endpoints to retrieve them.
 * `all_day` - when set to `true`, the schedule entry will not have a specific start or end time, and instead will be held for the entire day or days denoted in `starts_at` and `ends_at`
 * `notify` - when set to `true`, will notify the participants about the entry
+* `recurrence_schedule` - makes the entry recurring. An object with:
+  * `frequency` - one of `every_day`, `every_weekday`, `every_week`, `every_other_week`, `every_month`, `every_day_of_month`, `every_year`, `custom_week`, or `custom_month`
+  * `days` - for `every_day`: which days of the week to recur on, as integers `0` (Sunday) through `6` (Saturday); omit to recur every day. For `custom_month` without a `week_instance`: which day of the month to recur on, `1` to `31`. Derived from `starts_at` for the other frequencies.
+  * `week_instance` - for `every_month` and `custom_month`: which week of the month, `1` to `4`, or `-1` for the last week
+  * `week_interval` - for `custom_week`: repeat every `2` to `12` weeks
+  * `month_interval` - for `custom_month`: repeat every `2` to `12` months
+* `recurs_until` - date (ISO 8601) the recurrence ends. Omit to recur indefinitely. Reflected as `recurrence_schedule.end_date` in the response.
+
+The remaining `recurrence_schedule` attributes shown in [Get a schedule entry](#get-a-schedule-entry) (`hour`, `minute`, `start_date`, `duration`, `end_date`) are derived from `starts_at`, `ends_at`, and `recurs_until` — they're ignored on input. An invalid `recurrence_schedule` is discarded on create: the entry is created without recurring.
 
 This endpoint will return `201 Created` with the current JSON representation of the schedule entry if the creation was a success. See the [Get a schedule entry](#get-a-schedule-entry) endpoint for more info on the payload.
 
@@ -285,6 +294,18 @@ This endpoint will return `201 Created` with the current JSON representation of 
   "summary": "Important Meeting",
   "starts_at": "2015-06-04T00:00:00Z",
   "ends_at": "2015-06-04T02:00:00Z"
+}
+```
+
+###### Example JSON Request (recurring)
+
+```json
+{
+  "summary": "Weekly sync",
+  "starts_at": "2015-06-04T15:00:00Z",
+  "ends_at": "2015-06-04T16:00:00Z",
+  "recurrence_schedule": { "frequency": "every_week" },
+  "recurs_until": "2015-12-18"
 }
 ```
 
@@ -302,7 +323,7 @@ Update a schedule entry
 
 * `PUT /schedule_entries/2.json` allows changing of the schedule entry with an ID of `2`.
 
-Clients may change any of the required or optional parameters as listed in the [Create a schedule entry](#create-a-schedule-entry) endpoint.
+Clients may change any of the required or optional parameters as listed in the [Create a schedule entry](#create-a-schedule-entry) endpoint. That includes adding a `recurrence_schedule` to make a non-recurring entry recur. An entry that already recurs can't be changed through this endpoint, though: it redirects to the entry's first occurrence, like [Get a schedule entry](#get-a-schedule-entry) does.
 
 This endpoint will return `200 OK` with the current JSON representation of the schedule entry if the update was a success. See the [Get a schedule entry](#get-a-schedule-entry) endpoint for more info on the payload.
 

--- a/sections/todos.md
+++ b/sections/todos.md
@@ -273,6 +273,7 @@ Create a to-do
 --------------
 
 * `POST /todolists/3/todos.json` creates a to-do under the to-do list with an ID of `3`.
+* `POST /buckets/1/todosets/2/todos.json` creates a to-do directly under the to-do set with an ID of `2` in the project with ID `1`, outside of any to-do list. This form is only available project-scoped. See the [Get to-do set][todoset] endpoint to find a project's to-do set.
 
 **Required parameters**: `content` for what the to-do is for.
 
@@ -428,3 +429,4 @@ The following project-scoped routes are still supported and will remain availabl
 [2]: ../README.md#pagination
 [3]: rich_text.md
 [4]: people.md#get-all-people
+[todoset]: todosets.md#get-to-do-set


### PR DESCRIPTION
Three sections gain documentation for capabilities that are live in the Basecamp 5 API today.

## Campfires: edit and delete lines

[sections/campfires.md](sections/campfires.md) now documents updating a Campfire line — `PUT /chats/:chat/lines/:id.json` with new `content`, returning `204 No Content`. Lines can be edited only by their creator, and the edited line becomes a rich text line, so the content may use the HTML covered in the rich text guide. Deleting a line (creator or an admin) is documented alongside, and its cURL example now correctly shows `-X DELETE`.

## Schedule entries: recurring events via the API

[sections/schedule_entries.md](sections/schedule_entries.md) documents the recurrence write parameters: pass `recurrence_schedule` and `recurs_until` when creating a schedule entry, or when updating a non-recurring one, to make it recur. The section covers each frequency's `days` semantics, which schedule attributes are derived from `starts_at`/`ends_at`, and how requests for a recurring series redirect to its first occurrence (individual occurrences are fetchable by date).

## To-dos: create directly in a to-do set

[sections/todos.md](sections/todos.md) documents creating a to-do directly under a project's to-do set, outside any to-do list: `POST /buckets/:project/todosets/:todoset/todos.json`.

## Compatibility

Documentation-only. These endpoints already exist and behave as described; no wire-format or breaking changes.