### PR TITLE
Fix the schedule entry create cURL example

### DIFF
--- a/sections/schedule_entries.md
+++ b/sections/schedule_entries.md
@@ -313,7 +313,7 @@ This endpoint will return `201 Created` with the current JSON representation of 
 
 ```shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
-  -d '{"summary":"Important Meeting","starts_at":"2015-06-04T00:00:00Z","ends_at":"2015-06-04T00:00:00Z"}' \
+  -d '{"summary":"Important Meeting","starts_at":"2015-06-04T00:00:00Z","ends_at":"2015-06-04T02:00:00Z"}' \
   https://3.basecampapi.com/$ACCOUNT_ID/schedules/3/entries.json
 ```
 


### PR DESCRIPTION
Small docs fix: the "Create a schedule entry" cURL example's `ends_at` was identical to its `starts_at`, while the JSON request example above it shows a two-hour meeting. The cURL payload now matches — copying it creates the meeting the example describes.

Documentation-only; no API changes.