### PR TITLE
Document create-time visible_to_clients on content creates

### DIFF
--- a/sections/client_visibility.md
+++ b/sections/client_visibility.md
@@ -14,7 +14,7 @@ Toggle client visibility
 
 **Required parameter**: `visible_to_clients` with value `true` or `false`.
 
-This endpoint will return `200 OK` with the current JSON representation of the recording if the update was a success. Notice that not all recordings allow toggling client visibility, some inherit the visibility of their parent. For example, individual to-dos inherit the visibility of the to-do list they belong to. This endpoint will return `403 Forbidden` if the recording provided doesn't control its client visibility.
+This endpoint will return `200 OK` with the current JSON representation of the recording if the update was a success. Notice that not all recordings allow toggling client visibility, some inherit the visibility of their parent. For example, individual to-dos inherit the visibility of the to-do list they belong to, and individual cards inherit the visibility of their card table. This endpoint will return `403 Forbidden` if the recording provided doesn't control its client visibility.
 
 ###### Example JSON Request
 

--- a/sections/cloud_files.md
+++ b/sections/cloud_files.md
@@ -127,7 +127,7 @@ Create a cloud file
 | `title`       | String | The cloud file's title. Defaults to `Untitled` when omitted. |
 | `description` | HTML    | Rich-text description for the cloud file. |
 | `subscriptions` | Array<Integer> | IDs of [people][people] to subscribe to comments and boosts. |
-| `visible_to_clients` | Boolean | When the project has a [client][client_visibility] enabled, whether the cloud file is visible to them. Defaults to `false`. |
+| `visible_to_clients` | Boolean | A **top-level** field — a sibling of the `cloud_file` object, *not* inside it. When the project has clients enabled, whether the cloud file is visible to them. Defaults to `false`; a **client** caller always creates client-visible records. Applies only when creating directly in the tool's vault; items created inside a folder inherit the folder's visibility. See [Client visibility][client_visibility]. |
 
 [projects]: projects.md
 [people]: people.md

--- a/sections/documents.md
+++ b/sections/documents.md
@@ -169,7 +169,10 @@ Create a document
 
 **Required parameters**: `title` as the title of the document, and `content` as the body of the document. See our [Rich text guide][rich] for what HTML tags are allowed.
 
-_Optional parameters_: . `status`, set to `active` to publish immediately.
+_Optional parameters_:
+
+* `status`, set to `active` to publish immediately.
+* `visible_to_clients` - top-level boolean. When the project has clients enabled, whether the document is visible to them. Defaults to `false` (team callers creating directly under the docked tool); a **client** caller always creates client-visible records. Applies only when creating directly in the tool's vault; items created inside a folder inherit the folder's visibility. See [Client visibility][client_visibility] to change it after creation.
 
 This endpoint will return `201 Created` with the current JSON representation of the document if the creation was a success. See the [Get a document](#get-a-document) endpoint for more info on the payload.
 
@@ -229,3 +232,4 @@ The following project-scoped routes are still supported and will remain availabl
 [trash]: recordings.md#trash-a-recording
 [vaults]: vaults.md#vaults
 [rich]: rich_text.md
+[client_visibility]: client_visibility.md

--- a/sections/google_documents.md
+++ b/sections/google_documents.md
@@ -118,7 +118,7 @@ Create a Google document
 | `description` | HTML    | Rich-text description. |
 | `status`      | String  | `active` to publish immediately, `drafted` to keep as a draft. Defaults to `drafted`. |
 | `subscriptions` | Array<Integer> | IDs of [people][people] to subscribe to comments and boosts. |
-| `visible_to_clients` | Boolean | When the project has a [client][client_visibility] enabled, whether the document is visible to them. Defaults to `false`. |
+| `visible_to_clients` | Boolean | A **top-level** field — a sibling of the `google_document` object, *not* inside it. When the project has clients enabled, whether the document is visible to them. Defaults to `false`; a **client** caller always creates client-visible records. Applies only when creating directly in the tool's vault; items created inside a folder inherit the folder's visibility. See [Client visibility][client_visibility]. |
 
 [projects]: projects.md
 [people]: people.md

--- a/sections/messages.md
+++ b/sections/messages.md
@@ -423,6 +423,7 @@ _Optional parameters_:
 * `content` as the body of the message. See our [Rich text guide][4] for what HTML tags are allowed.
 * `category_id` to set a type for the message. To get a list of all the message types for a project, see the [Get message types][5] endpoint. 
 * `subscriptions` an array of people IDs to be notified of the new message when it's posted and subscribed to it. If not present, all people on the project will be notified and subscribed.
+* `visible_to_clients` - top-level boolean. When the project has clients enabled, whether the message is visible to them. Defaults to `false` (team callers creating directly under the docked tool); a **client** caller always creates client-visible records. See [Client visibility][client_visibility] to change it after creation.
 
 This endpoint will return `201 Created` with the current JSON representation of the message if the creation was a success. See the [Get a message](#get-a-message) endpoint for more info on the payload.
 
@@ -508,3 +509,4 @@ The following project-scoped routes are still supported and will remain availabl
 [3]: message_boards.md#message-boards
 [4]: rich_text.md
 [5]: message_types.md#get-message-types
+[client_visibility]: client_visibility.md

--- a/sections/questions.md
+++ b/sections/questions.md
@@ -209,6 +209,10 @@ Create a question
   * `time_of_day` - the time to ask, e.g. `"9:00am"`.
   * `days` - an array of day numbers (0=Sunday through 6=Saturday), e.g. `["1","2","3","4","5"]` for weekdays.
 
+_Optional parameters_:
+
+* `visible_to_clients` - a **top-level** boolean — a sibling of the `question` object, *not* inside it. When the project has clients enabled, whether the question is visible to them. Defaults to `false`; a **client** caller always creates client-visible records. See [Client visibility][client_visibility] to change it after creation.
+
 This endpoint will return `201 Created` with the current JSON representation of the question if the creation was a success. See the [Get a question](#get-a-question) endpoint for more info on the payload.
 
 ###### Example JSON Request
@@ -222,7 +226,8 @@ This endpoint will return `201 Created` with the current JSON representation of 
       "time_of_day": "5:00pm",
       "days": ["1", "2", "3", "4", "5"]
     }
-  }
+  },
+  "visible_to_clients": true
 }
 ```
 
@@ -230,7 +235,7 @@ This endpoint will return `201 Created` with the current JSON representation of 
 
 ```shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
-  -d '{"question":{"title":"What did you work on today?","schedule":{"frequency":"every_day","time_of_day":"5:00pm","days":["1","2","3","4","5"]}}}' \
+  -d '{"question":{"title":"What did you work on today?","schedule":{"frequency":"every_day","time_of_day":"5:00pm","days":["1","2","3","4","5"]}},"visible_to_clients":true}' \
   https://3.basecampapi.com/$ACCOUNT_ID/questionnaires/2/questions.json
 ```
 
@@ -340,3 +345,4 @@ The following project-scoped routes are still supported and will remain availabl
 
 [pagination]: ../README.md#pagination
 [trash]: recordings.md#trash-a-recording
+[client_visibility]: client_visibility.md

--- a/sections/schedule_entries.md
+++ b/sections/schedule_entries.md
@@ -282,6 +282,7 @@ _Optional parameters_:
   * `week_interval` - for `custom_week`: repeat every `2` to `12` weeks
   * `month_interval` - for `custom_month`: repeat every `2` to `12` months
 * `recurs_until` - date (ISO 8601) the recurrence ends. Omit to recur indefinitely. Reflected as `recurrence_schedule.end_date` in the response.
+* `visible_to_clients` - top-level boolean. When the project has clients enabled, whether the schedule entry is visible to them. Defaults to `false` (team callers creating directly under the docked tool); a **client** caller always creates client-visible records. See [Client visibility][client_visibility] to change it after creation.
 
 The remaining `recurrence_schedule` attributes shown in [Get a schedule entry](#get-a-schedule-entry) (`hour`, `minute`, `start_date`, `duration`, `end_date`) are derived from `starts_at`, `ends_at`, and `recurs_until` — they're ignored on input. An invalid `recurrence_schedule` is discarded on create: the entry is created without recurring.
 
@@ -362,3 +363,4 @@ The following project-scoped routes are still supported and will remain availabl
 [schedule]: schedules.md#get-schedule
 [rich]: rich_text.md
 [people]: people.md#people
+[client_visibility]: client_visibility.md

--- a/sections/todolists.md
+++ b/sections/todolists.md
@@ -196,7 +196,10 @@ Create a to-do list
 
 **Required parameters**: `name` of the to-do list.
 
-_Optional parameters_: `description` containing information about the to-do list. See our [Rich text guide][rich] for what HTML tags are allowed.
+_Optional parameters_:
+
+* `description` containing information about the to-do list. See our [Rich text guide][rich] for what HTML tags are allowed.
+* `visible_to_clients` - top-level boolean. When the project has clients enabled, whether the to-do list is visible to them. Defaults to `false` (team callers creating directly under the docked tool); a **client** caller always creates client-visible records. See [Client visibility][client_visibility] to change it after creation.
 
 This endpoint will return `201 Created` with the current JSON representation of the to-do list if the creation was a success. See the [Get a to-do list](#get-a-to-do-list) endpoint for more info on the payload.
 
@@ -265,3 +268,4 @@ The following project-scoped routes are still supported and will remain availabl
 [todoset]: todosets.md#get-to-do-set
 [todos]: todos.md#to-dos
 [rich]: rich_text.md
+[client_visibility]: client_visibility.md

--- a/sections/uploads.md
+++ b/sections/uploads.md
@@ -244,6 +244,7 @@ Create an upload
 _Optional parameters_:
 * `description` - containing information about the upload. See our [Rich text guide][rich] for what HTML tags are allowed.
 * `base_name` - a new file name for the upload. `base_name` should be a file name *without* an extension (e.g. `"pizza"` for `"pizza.png"`).
+* `visible_to_clients` - top-level boolean. When the project has clients enabled, whether the upload is visible to them. Defaults to `false` (team callers creating directly under the docked tool); a **client** caller always creates client-visible records. Applies only when creating directly in the tool's vault; items created inside a folder inherit the folder's visibility. See [Client visibility][client_visibility] to change it after creation.
 
 This endpoint will return `201 Created` with the current JSON representation of the upload if the creation was a success. See the [Get an upload](#get-an-upload) endpoint for more info on the payload.
 
@@ -305,3 +306,4 @@ The following project-scoped routes are still supported and will remain availabl
 [trash]: recordings.md#trash-a-recording
 [vaults]: vaults.md#vaults
 [rich]: rich_text.md
+[client_visibility]: client_visibility.md


### PR DESCRIPTION
The create endpoints for messages, documents, to-do lists, questions, uploads, cloud files, Google documents, and schedule entries already accept a `visible_to_clients` flag, letting you post a recording and set its client visibility in a single request instead of following up with a [client visibility](sections/client_visibility.md) update. This documents that flag consistently across those create sections.

## What the docs now say

- **Always top-level.** For the sections whose request body nests fields under a wrapper object (`questions`, `cloud_files`, `google_documents`), the flag must be a **sibling** of that object, not inside it.
- **Defaults to `false`** for team members creating directly under the tool; a **client** always creates client-visible records.
- **Vault-based tools** (documents, uploads, cloud files, Google documents): applies only when creating directly in the tool's vault — items created inside a folder inherit the folder's visibility.

Also notes in the Client visibility section that individual cards inherit their card table's visibility, alongside the existing to-do note.

Recordings that inherit their visibility (individual to-dos and cards) can't be toggled individually — `PUT .../client_visibility` returns `403` for them — so their create sections intentionally don't document the flag.