### PR TITLE
Show visible_to_clients in cloud/google create examples

### DIFF
--- a/sections/cloud_files.md
+++ b/sections/cloud_files.md
@@ -142,7 +142,8 @@ Create a cloud file
     "description": "<div>Logos and color tokens</div>",
     "url": "https://www.dropbox.com/s/abcd1234/brand.zip",
     "service": "dropbox"
-  }
+  },
+  "visible_to_clients": true
 }
 ```
 <!-- END POST PAYLOAD /buckets/1/vaults/3/cloud_files.json -->
@@ -155,7 +156,7 @@ A successful create returns `201 Created` with the new cloud file's JSON shape:
 {
   "id": 1069480436,
   "status": "active",
-  "visible_to_clients": false,
+  "visible_to_clients": true,
   "created_at": "2026-07-21T01:06:09.387Z",
   "updated_at": "2026-07-21T01:06:09.422Z",
   "title": "Brand assets",
@@ -266,7 +267,7 @@ Returns `200 OK` with the updated cloud file's JSON shape:
 {
   "id": 1069480436,
   "status": "active",
-  "visible_to_clients": false,
+  "visible_to_clients": true,
   "created_at": "2026-07-21T01:06:09.387Z",
   "updated_at": "2026-07-21T01:06:10.012Z",
   "title": "Brand assets v2",

--- a/sections/cloud_files.md
+++ b/sections/cloud_files.md
@@ -230,7 +230,7 @@ A successful create returns `201 Created` with the new cloud file's JSON shape:
 
 ```shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
-  -d '{"cloud_file":{"title":"Brand assets","description":"<div>Logos and color tokens</div>","url":"https://www.dropbox.com/s/abcd1234/brand.zip","service":"dropbox"}}' \
+  -d '{"cloud_file":{"title":"Brand assets","description":"<div>Logos and color tokens</div>","url":"https://www.dropbox.com/s/abcd1234/brand.zip","service":"dropbox"},"visible_to_clients":true}' \
   https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/vaults/3/cloud_files.json
 ```
 

--- a/sections/google_documents.md
+++ b/sections/google_documents.md
@@ -133,7 +133,8 @@ Create a Google document
     "description": "<div>Quarterly roadmap document</div>",
     "url": "https://docs.google.com/document/d/abcd1234/edit",
     "document_type": "doc"
-  }
+  },
+  "visible_to_clients": true
 }
 ```
 <!-- END POST PAYLOAD /buckets/1/vaults/3/google_documents.json -->
@@ -146,7 +147,7 @@ A successful create returns `201 Created` with the new Google document's JSON sh
 {
   "id": 1069480443,
   "status": "drafted",
-  "visible_to_clients": false,
+  "visible_to_clients": true,
   "created_at": "2026-07-21T01:06:50.879Z",
   "updated_at": "2026-07-21T01:06:50.896Z",
   "title": "Roadmap",
@@ -249,7 +250,7 @@ Returns `200 OK` with the updated Google document's JSON shape:
 {
   "id": 1069480443,
   "status": "drafted",
-  "visible_to_clients": false,
+  "visible_to_clients": true,
   "created_at": "2026-07-21T01:06:50.879Z",
   "updated_at": "2026-07-21T01:06:51.456Z",
   "title": "Roadmap (revised)",

--- a/sections/google_documents.md
+++ b/sections/google_documents.md
@@ -212,7 +212,7 @@ A successful create returns `201 Created` with the new Google document's JSON sh
 
 ```shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" \
-  -d '{"google_document":{"title":"Roadmap","description":"<div>Quarterly roadmap document</div>","url":"https://docs.google.com/document/d/abcd1234/edit","document_type":"doc"}}' \
+  -d '{"google_document":{"title":"Roadmap","description":"<div>Quarterly roadmap document</div>","url":"https://docs.google.com/document/d/abcd1234/edit","document_type":"doc"},"visible_to_clients":true}' \
   https://3.basecampapi.com/$ACCOUNT_ID/buckets/1/vaults/3/google_documents.json
 ```
 


### PR DESCRIPTION
The [cloud file](sections/cloud_files.md) and [Google document](sections/google_documents.md) sections already describe the top-level `visible_to_clients` create parameter in prose, but the create request/response examples didn't show it.

This surfaces it in the examples: the create payloads gain the top-level `visible_to_clients` field, and the create/update response blocks show `"visible_to_clients": true`, so readers copying the examples see the parameter in place. Documentation only.

---

> Synced from bc3 `doc/api/` by `script/api/sync_to_bc3_api` — not a hand-edit.