### PR TITLE
Schedule entries: participants are only replaced when addressed

### DIFF
--- a/sections/schedule_entries.md
+++ b/sections/schedule_entries.md
@@ -329,6 +329,8 @@ Clients may change any of the required or optional parameters as listed in the [
 
 This endpoint will return `200 OK` with the current JSON representation of the schedule entry if the update was a success. See the [Get a schedule entry](#get-a-schedule-entry) endpoint for more info on the payload.
 
+Participants are only replaced when you address them: omit `participant_ids` and the entry keeps its current participants; send `"participant_ids": []` to remove them all.
+
 ###### Example JSON Request
 
 ```json


### PR DESCRIPTION
Updating a schedule entry no longer clobbers participants by default: `PUT` requests that omit `participant_ids` keep the entry's current participants, and sending `"participant_ids": []` removes them all. The [Update a schedule entry](sections/schedule_entries.md#update-a-schedule-entry) docs now say so.

---

Synced from bc3 `doc/api/` by `script/api/sync_to_bc3_api` — not a hand-edit.
