### PR TITLE
Files feed: document parent for images hotlinked into chats

### DIFF
--- a/sections/everything.md
+++ b/sections/everything.md
@@ -15222,7 +15222,10 @@ List files
   shapes; attachments are wrapped in a
   recording envelope plus an `attachable_sgid` and blob metadata
   (`filename`, `content_type`, `byte_size`, `download_url`, …), with
-  `parent` identifying the doc/message the attachment lives in.
+  `parent` identifying the recording the attachment hangs from: the
+  doc/message it lives in or, for images hotlinked into a chat, the
+  autolinked-image wrapper whose `url` and `app_url` point at the
+  surrounding chat line.
 
 Two optional query parameters narrow the list:
 


### PR DESCRIPTION
`GET /files.json` wraps rich-text attachments in a recording envelope whose `parent` identifies the recording the attachment hangs from. For most attachments that is the document or message they live in — but an image hotlinked into a chat is recorded under an autolinked-image wrapper, so that wrapper is the `parent`: its `title` is the image's source URL, and its `url` and `app_url` point at the surrounding chat line.

This documents that case. (Requests for pages surfacing such attachments previously returned an error; they now render, with the parent shape described here.)

Synced from bc3 `doc/api/` by `script/api/sync_to_bc3_api` — not a hand-edit.