### PR TITLE
Deprioritize is exact-target; repeat-DELETE is a no-op

### DIFF
--- a/sections/my_assignments.md
+++ b/sections/my_assignments.md
@@ -690,6 +690,8 @@ Deprioritize an assignment
 
 * `DELETE /my/priorities/1069479801.json` removes the recording with an ID of `1069479801` from Up Next. Returns `204 No Content`.
 
+The delete is **exact-target**: it clears only the priority carried by the recording the URL identifies, and deleting a recording that carries no priority is a **no-op** that still returns `204 No Content` — so a repeated `DELETE` (a client retry after a lost response) is safe and never touches any other priority. To deprioritize a card table step surfaced under its parent card, send the step's own id — the `priority_recording_id` reported by [Get assignments](#get-assignments) — not the card's id.
+
 ###### Copy as cURL
 
 ```shell


### PR DESCRIPTION
Mirrors basecamp/bc3#12483 (merged as `d0edc128`): the priorities DELETE clears only the priority carried by the recording the URL identifies, deleting an absent priority is a no-op `204`, and card table steps surfaced under their parent card are addressed by their `priority_recording_id`.

Synced from bc3 `doc/api/` by `script/api/sync_to_bc3_api` — not a hand-edit.