### PR TITLE
Card steps and cards: partial updates

### DIFF
--- a/sections/card_table_cards.md
+++ b/sections/card_table_cards.md
@@ -394,7 +394,7 @@ _Optional parameters_:
 * `due_on` - due date (ISO 8601) of the card
 * `assignee_ids` - an array of people that will be assigned to this card. Please see the [Get people][people] endpoints to retrieve them.
 
-**Note:** omitting `title`, `content`, or `assignee_ids` leaves those values unchanged, but omitting `due_on` **clears** the due date. To keep an existing due date while changing something else, resend the current `due_on`.
+**Note:** this is a partial update — omitting any of `title`, `content`, `due_on`, or `assignee_ids` leaves it unchanged. To clear the due date, send `"due_on": null` explicitly; to remove all assignees, send `"assignee_ids": []`.
 
 This endpoint will return `200 OK` with the current JSON representation of the card if the update was a success. See the [Get a card](#get-a-card) endpoint for more info on the payload.
 

--- a/sections/card_table_steps.md
+++ b/sections/card_table_steps.md
@@ -66,7 +66,13 @@ _Optional parameters_:
 * `assignee_ids` - an array of people ids that will be assigned to this step. Please see the [Get people][people] endpoints to retrieve them.
 * `assignees` - a comma separated list of people ids (legacy format, prefer `assignee_ids`).
 
-**Note:** this update **replaces** the step — any of `title`, `due_on`, or `assignee_ids` you omit is cleared. Resend the values you want to keep.
+**Note:** this is a partial update — any parameter you omit is left unchanged. To clear a value, send it explicitly:
+
+| To…                    | Send                     |
+| ---------------------- | ------------------------ |
+| leave a value unchanged | omit the parameter      |
+| clear the due date     | `"due_on": null`         |
+| remove all assignees   | `"assignee_ids": []`     |
 
 This endpoint will return `200 OK` with the current JSON representation of the step if the update was a success. See the step property of the [Get a card][card] endpoint for more info on the payload.
 


### PR DESCRIPTION
Updating a card table step or card is becoming a true partial update on the JSON API: parameters you omit are left unchanged, instead of being cleared.

**Steps** (`PUT /card_tables/steps/{id}.json`): previously this update replaced the whole step — any of `title`, `due_on`, or `assignee_ids` you omitted was cleared, and `title` was required. Now each of them may be omitted independently and keeps its current value.

**Cards** (`PUT /card_tables/cards/{id}.json`): previously omitting `due_on` cleared the card's due date even when you only meant to change something else. Now an omitted `due_on` is left unchanged, matching the other parameters.

To clear a value, send it explicitly:

| To… | Send |
| --- | --- |
| leave a value unchanged | omit the parameter |
| clear the due date | `"due_on": null` |
| remove all assignees | `"assignee_ids": []` |

Creating a step is unchanged: `title` is still required.

These docs describe the new behavior and will merge when it reaches production.

Synced from bc3 `doc/api/` by `script/api/sync_to_bc3_api` — not a hand-edit.