### PR TITLE
A project's status is read-only on Update a project

### DIFF
--- a/sections/projects.md
+++ b/sections/projects.md
@@ -552,6 +552,8 @@ _Optional parameters_:
 
 This will return `200 OK` with the current JSON representation of the project if the update was a success. See the [Get a project](#get-a-project) endpoint for more info.
 
+A project's `status` is read-only here. Passing a `status` has no effect and still returns `200 OK`. To change it, see [Archive a project](#archive-a-project), [Unarchive a project](#unarchive-a-project), and [Trash a project](#trash-a-project).
+
 ###### Copy as cURL
 
 ```shell


### PR DESCRIPTION
`PUT /projects/:id.json` has never been able to change a project's status, but the docs didn't say so — and the request answers `200 OK` either way, so a client passing a `status` gets no signal that the param was dropped.

This adds a paragraph to **Update a project** saying `status` is read-only there, and pointing at **Archive a project**, **Unarchive a project**, and **Trash a project** as the endpoints that do change it.

No API behavior changed. `status` was already ignored on this endpoint, and still is — read-modify-write clients that PUT a whole project object back, `status` included, keep working exactly as before.

---

Synced from bc3 `doc/api/` by `script/api/sync_to_bc3_api` — not a hand-edit.
